### PR TITLE
Added variable initialization to avoid python runtime erorrs

### DIFF
--- a/edalize/symbiflow.py
+++ b/edalize/symbiflow.py
@@ -242,6 +242,9 @@ endif
         commands.write(os.path.join(self.work_root, "Makefile"))
 
     def configure_vpr(self):
+        bitstream_device = ""
+        partname = ""
+        device_suffix = ""
         (src_files, incdirs) = self._get_fileset_files(force_slash=True)
 
         has_vhdl = "vhdlSource" in [x.file_type for x in src_files]


### PR DESCRIPTION
@jgoeders take a look at this change and see what you think. If you run edalize symbiflow without that initialization you get some weird errors that have to do with the scope of the variable initialization.