### PR TITLE
Direct port of symbiflow_synth Yosys calls into Edalize-generated Makefile

### DIFF
--- a/edalize/symbiflow.py
+++ b/edalize/symbiflow.py
@@ -324,7 +324,7 @@ endif
         commands.add_make_var('F4PGA_SYNTH_TCL_PATH', commands.get_make_var('F4PGA_UTILS_PATH') + "${FPGA_FAM}/synth.tcl")
         commands.add_make_var('F4PGA_CONV_TCL_PATH', commands.get_make_var('F4PGA_UTILS_PATH') + "${FPGA_FAM}/conv.tcl")
         commands.add_make_var('F4PGA_SPLIT_INOUTS_PATH', commands.get_make_var('F4PGA_UTILS_PATH') + "split_inouts.py")
-        commands.add_make_var('F4PGA_DATABASE_DIR', "$(prjxray-config)")
+        commands.add_make_var('F4PGA_DATABASE_DIR', "$(shell prjxray-config)")
         commands.add_make_var('F4PGA_SYNTH_TOOL', "yosys")
         commands.add_make_var('F4PGA_PYTHON', "python3")
 
@@ -362,7 +362,7 @@ endif
         commands.add_env_var('OUT_SDC', self.toplevel + ".sdc")
         commands.add_env_var('TOP', commands.get_make_var('F4PGA_TOP_MODULE'))
         commands.add_env_var('INPUT_XDC_FILES', commands.get_make_var('F4PGA_PLACE_CONSTRAINT_FILES'))
-        commands.add_env_var('PART_JSON', 'realpath {}/{}/{}/part.json'.format(
+        commands.add_env_var('PART_JSON', '{}/{}/{}/part.json'.format(
                                                                             commands.get_make_var('F4PGA_DATABASE_DIR'),
                                                                             commands.get_make_var('F4PGA_DEVICE_TYPE'),
                                                                             commands.get_make_var('F4PGA_PART_NAME')))
@@ -371,9 +371,7 @@ endif
         commands.add_env_var('UTILS_PATH', commands.get_make_var('F4PGA_UTILS_PATH'))
         commands.add_env_var('OUT_JSON', commands.get_make_var('F4PGA_SYNTH_INTERMEDIATE_1'))
         commands.add_env_var('PYTHON3', commands.get_make_var('F4PGA_PYTHON'))
-        #commands.add_env_var('', )
-        #commands.add_env_var('', )
-        #commands.add_env_var('', )
+        commands.add_env_var('OUT_EBLIF', commands.get_make_var('F4PGA_EBLIF_NAME'))
 
         # Synthesis
         #targets = commands.get_make_var('F4PGA_EBLIF_NAME')

--- a/edalize/symbiflow.py
+++ b/edalize/symbiflow.py
@@ -300,10 +300,10 @@ endif
 
          # Symbiflow variables
         commands.add_make_var('F4PGA_TOP_MODULE', self.toplevel)
-        commands.add_make_var('F4PGA_VERILOG_FILES', '\'{}\''.format(' '.join(file_list)))
-        commands.add_make_var('F4PGA_TIMING_CONSTRAINT_FILES', '\'{}\''.format(' '.join(timing_constraints)))
-        commands.add_make_var('F4PGA_PIN_CONSTRAINT_FILES', '\'{}\''.format(' '.join(pins_constraints)))
-        commands.add_make_var('F4PGA_PLACE_CONSTRAINT_FILES', '\'{}\''.format(' '.join(placement_constraints)))
+        commands.add_make_var('F4PGA_VERILOG_FILES', '{}'.format(' '.join(file_list)))
+        commands.add_make_var('F4PGA_TIMING_CONSTRAINT_FILES', '{}'.format(' '.join(timing_constraints)))
+        commands.add_make_var('F4PGA_PIN_CONSTRAINT_FILES', '{}'.format(' '.join(pins_constraints)))
+        commands.add_make_var('F4PGA_PLACE_CONSTRAINT_FILES', '{}'.format(' '.join(placement_constraints)))
 
         commands.add_make_var('F4PGA_DEVICE_TYPE', bitstream_device)
         commands.add_make_var('F4PGA_PART_NAME', partname)
@@ -320,6 +320,32 @@ endif
         commands.add_make_var('F4PGA_OPENOCD_NAME', self.toplevel + ".openocd.cfg")
         commands.add_make_var('F4PGA_JLINK_NAME', self.toplevel + ".jlink")
 
+        commands.add_make_var('F4PGA_UTILS_PATH', "${INSTALL_DIR}/${FPGA_FAM}/install/share/symbiflow/scripts/")
+        commands.add_make_var('F4PGA_SYNTH_TCL_PATH', commands.get_make_var('F4PGA_UTILS_PATH') + "${FPGA_FAM}/synth.tcl")
+        commands.add_make_var('F4PGA_CONV_TCL_PATH', commands.get_make_var('F4PGA_UTILS_PATH') + "${FPGA_FAM}/conv.tcl")
+        commands.add_make_var('F4PGA_SPLIT_INOUTS_PATH', commands.get_make_var('F4PGA_UTILS_PATH') + "split_inouts.py")
+        commands.add_make_var('F4PGA_DATABASE_DIR', "$(prjxray-config)")
+        commands.add_make_var('F4PGA_SYNTH_TOOL', "yosys")
+        commands.add_make_var('F4PGA_PYTHON', "python3")
+
+        commands.add_make_var('F4PGA_SYNTH_LOG', self.toplevel + "_synth.log")
+        commands.add_make_var('F4PGA_SYNTH_INTERMEDIATE_1', self.toplevel + ".json")
+        commands.add_make_var('F4PGA_SYNTH_INTERMEDIATE_2', self.toplevel + "_io.json")
+
+        commands.add_make_var('F4PGA_SYNTH_ARGS_YOSYS_1', '-p \"tcl {}\" -l {} {}'.format(
+                                                                                    commands.get_make_var('F4PGA_SYNTH_TCL_PATH'), 
+                                                                                    commands.get_make_var('F4PGA_SYNTH_LOG'),
+                                                                                    commands.get_make_var('F4PGA_VERILOG_FILES')))
+        
+        commands.add_make_var('F4PGA_SYNTH_ARGS_PYTHON', '{} -i {} -o {}'.format(
+                                                                            commands.get_make_var('F4PGA_SPLIT_INOUTS_PATH'), 
+                                                                            commands.get_make_var('F4PGA_SYNTH_INTERMEDIATE_1'), 
+                                                                            commands.get_make_var('F4PGA_SYNTH_INTERMEDIATE_2')))
+        commands.add_make_var('F4PGA_SYNTH_ARGS_YOSYS_2', '-p \"read_json {}; tcl {}\"'.format(
+                                                                                            commands.get_make_var('F4PGA_SYNTH_INTERMEDIATE_2'),
+                                                                                            commands.get_make_var('F4PGA_CONV_TCL_PATH')))
+        
+
         _vo = self.tool_options.get("vpr_options")
         vpr_options = ["--additional_vpr_options", f'"{_vo}"'] if _vo else []
         pcf_opts = ["-p"] + [commands.get_make_var('F4PGA_PIN_CONSTRAINT_FILES')] if pins_constraints else []
@@ -330,16 +356,51 @@ endif
         commands.add_env_var('EDALIZE_VENDOR', vendor)
         commands.add_env_var('EDALIZE_PART', part)
 
+        # Add synth env variables
+        commands.add_env_var('USE_ROI', "FALSE")
+        commands.add_env_var('TECHMAP_PATH', "${INSTALL_DIR}/${FPGA_FAM}/install/share/symbiflow/techmaps/xc7_vpr/techmap")
+        commands.add_env_var('OUT_SDC', self.toplevel + ".sdc")
+        commands.add_env_var('TOP', commands.get_make_var('F4PGA_TOP_MODULE'))
+        commands.add_env_var('INPUT_XDC_FILES', commands.get_make_var('F4PGA_PLACE_CONSTRAINT_FILES'))
+        commands.add_env_var('PART_JSON', 'realpath {}/{}/{}/part.json'.format(
+                                                                            commands.get_make_var('F4PGA_DATABASE_DIR'),
+                                                                            commands.get_make_var('F4PGA_DEVICE_TYPE'),
+                                                                            commands.get_make_var('F4PGA_PART_NAME')))
+        commands.add_env_var('OUT_FASM_EXTRA', self.toplevel + "_fasm_extra.fasm")
+        commands.add_env_var('OUT_SYNTH_V', self.toplevel + "_synth.v")
+        commands.add_env_var('UTILS_PATH', commands.get_make_var('F4PGA_UTILS_PATH'))
+        commands.add_env_var('OUT_JSON', commands.get_make_var('F4PGA_SYNTH_INTERMEDIATE_1'))
+        commands.add_env_var('PYTHON3', commands.get_make_var('F4PGA_PYTHON'))
+        #commands.add_env_var('', )
+        #commands.add_env_var('', )
+        #commands.add_env_var('', )
+
         # Synthesis
-        targets = commands.get_make_var('F4PGA_EBLIF_NAME')
-        command = ["symbiflow_synth", "-t", commands.get_make_var('F4PGA_TOP_MODULE')]
-        command += ["-v"] + [commands.get_make_var('F4PGA_VERILOG_FILES')]
-        command += ["-d", commands.get_make_var('F4PGA_DEVICE_TYPE')]
-        command += ["-p" if vendor == "xilinx" else "-P", commands.get_make_var('F4PGA_PART_NAME')]
-        if vendor == "quicklogic" and pins_constraints:
-            command += pcf_opts
-        command += xdc_opts
-        commands.add(command, [targets], [])
+        #targets = commands.get_make_var('F4PGA_EBLIF_NAME')
+        #command = ["symbiflow_synth", "-t", commands.get_make_var('F4PGA_TOP_MODULE')]
+        #command += ["-v"] + [commands.get_make_var('F4PGA_VERILOG_FILES')]
+        #command += ["-d", commands.get_make_var('F4PGA_DEVICE_TYPE')]
+        #command += ["-p" if vendor == "xilinx" else "-P", commands.get_make_var('F4PGA_PART_NAME')]
+        #if vendor == "quicklogic" and pins_constraints:
+        #    command += pcf_opts
+        #command += xdc_opts
+        #commands.add(command, [targets], [])
+
+        # Synthesis - Yosys direct
+        yosysTarget1 = commands.get_make_var('F4PGA_SYNTH_INTERMEDIATE_1')
+        yosysDepend1 = commands.get_make_var('F4PGA_VERILOG_FILES')
+        yosysCommand1 = [commands.get_make_var('F4PGA_SYNTH_TOOL'), commands.get_make_var('F4PGA_SYNTH_ARGS_YOSYS_1')]
+        commands.add(yosysCommand1, [yosysTarget1], [yosysDepend1])
+
+        pythonTarget = commands.get_make_var('F4PGA_SYNTH_INTERMEDIATE_2')
+        pythonDepend = commands.get_make_var('F4PGA_SYNTH_INTERMEDIATE_1')
+        pythonCommand = [commands.get_make_var('F4PGA_PYTHON'), commands.get_make_var('F4PGA_SYNTH_ARGS_PYTHON')]
+        commands.add(pythonCommand, [pythonTarget], [pythonDepend])
+
+        yosysTarget2 = commands.get_make_var('F4PGA_EBLIF_NAME')
+        yosysDepend2 = commands.get_make_var('F4PGA_SYNTH_INTERMEDIATE_2')
+        yosysCommand2 = [commands.get_make_var('F4PGA_SYNTH_TOOL'), commands.get_make_var('F4PGA_SYNTH_ARGS_YOSYS_2')]
+        commands.add(yosysCommand2, [yosysTarget2], [yosysDepend2])
 
         # P&R
         eblif_opt = ["-e", commands.get_make_var('F4PGA_EBLIF_NAME')]

--- a/edalize/utils.py
+++ b/edalize/utils.py
@@ -53,14 +53,31 @@ class EdaCommands(object):
                 if c.command:
                     f.write(f"\t$(EDALIZE_LAUNCHER) {' '.join(c.command)}\n")
 
-    # Adds an environmental variable with the given name and value
     def add_env_var(self, name, value):
+        """Adds an environmental variable to the Makefile
+
+        Args:
+            name: The variable name
+            value: The value to set the variable to
+        """
         self.vars.append('export {name}={value}'.format(name=name, value=value))
 
-    # Adds a make variable with the given name and value
     def add_make_var(self, name, value):
+        """Adds a regular make variable to the Makefile
+
+        Args:
+            name: The variable name
+            value: THe value to set the variable to
+        """
         self.make_vars.append('{name}={value}'.format(name=name, value=value))
 
-    # Returns a formatted string representing the make variable with the name
     def get_make_var(self, name):
+        """Returns a make variable token string with the given name
+        
+        Args:
+            name: The variable name
+
+        Returns:
+            str: The make variable token, usable in the file
+        """
         return '$({name})'.format(name=name)

--- a/edalize/utils.py
+++ b/edalize/utils.py
@@ -25,13 +25,13 @@ class EdaCommands(object):
         with open(outfile, "w") as f:
             f.write(self.header)
 
-            for v in self.vars:
-                f.write(v + "\n")
-            if self.vars:
-                f.write("\n")
             for v in self.make_vars:
                 f.write(v + "\n")
             if self.make_vars:
+                f.write("\n")
+            for v in self.vars:
+                f.write(v + "\n")
+            if self.vars:
                 f.write("\n")
             
             if not self.default_target:


### PR DESCRIPTION
This is essentially Step 1 of our project (see #302), as it ports over the three calls (Yosys, Python, Yosys) from the symbiflow_synth script over to the Makefile generated by Edalize. 

Because of how Edalize generates makefiles, three new targets/rules were created for this process, one for each of the three calls. 

In addition, the way Edalize generates Symbiflow/F4PGA makefiles was restructured so that it makes use of Make variables instead of hardcoding the filenames and options into the recipes themselves.

THe environmental variables now print in the Makefile after the Make variables because the Yosys TCL scripts need a whole bunch of environmental variables which can easily be generated using the make variables.

SystemVerilog files are now supported, you simply specify the file type in the EDAM as `systemVerilogSource`.

I have tested this on a whole suite of SystemVerilog and regular Verilog files, including all of my labs from 220. I've made them available in [this](https://github.com/Pocketkid2/Edalize-Examples) repo.